### PR TITLE
Fixes CI badge to show main branch status

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1,6 +1,9 @@
 name: Lint & Format Checks
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Windows platform](https://img.shields.io/badge/platform-windows--64-orange.svg)](https://www.microsoft.com/en-us/)
 [![DOI](https://zenodo.org/badge/968772915.svg)](https://zenodo.org/badge/latestdoi/968772915)
 [![License](https://img.shields.io/badge/license-BSD--3-yellow.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![CI Test](https://github.com/MuammerBay/isaac_so_arm101/actions/workflows/ci-test.yml/badge.svg?branch=main)](https://github.com/MuammerBay/isaac_so_arm101/actions/workflows/ci-test.yml)
+[![ci-test](https://github.com/MuammerBay/isaac_so_arm101/actions/workflows/ci-test.yml/badge.svg?branch=main)](https://github.com/MuammerBay/isaac_so_arm101/actions/workflows/ci-test.yml)
 
 This repository implements tasks for the SO‑ARM100 and SO‑ARM101 robots using Isaac Lab. It serves as the foundation for several tutorials in the LycheeAI Hub series [Project: SO‑ARM101 × Isaac Sim × Isaac Lab](https://lycheeai-hub.com/project-so-arm101-x-isaac-sim-x-isaac-lab-tutorial-series).
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@
 [![Windows platform](https://img.shields.io/badge/platform-windows--64-orange.svg)](https://www.microsoft.com/en-us/)
 [![DOI](https://zenodo.org/badge/968772915.svg)](https://zenodo.org/badge/latestdoi/968772915)
 [![License](https://img.shields.io/badge/license-BSD--3-yellow.svg)](https://opensource.org/licenses/BSD-3-Clause)
-
-<!-- TODO: find a way to add this pre-commit badge but will need correcting the CI pipeline -->
-<!-- [![pre-commit](https://img.shields.io/github/actions/workflow/status/MuammerBay/isaac_so_arm101/ci-test.yaml?logo=ci-test&logoColor=white&label=ci-test&color=brightgreen)](https://github.com/MuammerBay/isaac_so_arm101/actions/workflows/ci-test.yml) -->
-
+[![CI Test](https://github.com/MuammerBay/isaac_so_arm101/actions/workflows/ci-test.yml/badge.svg?branch=main)](https://github.com/MuammerBay/isaac_so_arm101/actions/workflows/ci-test.yml)
 
 This repository implements tasks for the SO‑ARM100 and SO‑ARM101 robots using Isaac Lab. It serves as the foundation for several tutorials in the LycheeAI Hub series [Project: SO‑ARM101 × Isaac Sim × Isaac Lab](https://lycheeai-hub.com/project-so-arm101-x-isaac-sim-x-isaac-lab-tutorial-series).
 


### PR DESCRIPTION
## Summary
Fixes the CI badge to always reflect the main branch status instead of PR status.

## Changes
- Added `push` trigger to CI workflow for main branch
- Updated README badge to specifically track main branch using `?branch=main`

Resolves #54